### PR TITLE
wrong execution path for index.js fixed

### DIFF
--- a/cli
+++ b/cli
@@ -18,7 +18,7 @@ function start() {
     }
 
     pm2.start({
-      script: 'index.js',
+      script: path.join(__dirname,'index.js'),
       name: 'xcarve',
       cwd: process.cwd()
     }, (err, apps) => {


### PR DESCRIPTION
 Same issue and same fix like here with the proxy (adafruit/xcarve-proxy#1)

Issue appeared on:
- Raspberry Pi Zero
- Raspbian 4.4.21
- Node.js 4.2.6
